### PR TITLE
Add option for custom normals

### DIFF
--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -43,6 +43,16 @@ enum ScatterType { BOX, SPHERE }
 
 		_update()
 
+## Manually set the normal direction of mesh instances.
+## If [code]custom_normal[/code] is set to (0,0,0) then the
+## normal of the terrain will be used by default.
+## [br][br] This vector is automatically normalized.
+@export var custom_normal := Vector3(0.0, 0.0, 0.0):
+	get: return custom_normal
+	set(value):
+		custom_normal = value
+		_update()
+
 ## The placement size of the bounding box.
 ## Enable [code]show_debug_area[/code] to view the size of the bounding box.
 ## [br][br] Note: If the [code]scatter_type[/code] is set to Sphere,
@@ -417,6 +427,9 @@ func scatter(force := false) -> void:
 
 		var iteration_scale := base_scale
 
+		if custom_normal != Vector3(0.0, 0.0, 0.0):
+			hit.normal = custom_normal.normalized()
+		
 		# Angle constraints check
 		if use_angle:
 			var off: float = rad_to_deg((abs(hit.normal.x) + abs(hit.normal.z)) / 2.0)

--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -427,9 +427,9 @@ func scatter(force := false) -> void:
 
 		var iteration_scale := base_scale
 
-		if custom_normal != Vector3(0.0, 0.0, 0.0):
+		if not custom_normal.is_zero_approx():
 			hit.normal = custom_normal.normalized()
-		
+
 		# Angle constraints check
 		if use_angle:
 			var off: float = rad_to_deg((abs(hit.normal.x) + abs(hit.normal.z)) / 2.0)


### PR DESCRIPTION
As per #9 

Optionally allow custom normal to be set for mesh instances. Useful for cases like trees, where (for the most part) they stick straight up out of the ground. Random rotation still works on top of this normal setting.

With the custom normal set to (0,0,0), the normal of the terrain is used (this is explained in the dialog tooltip):
![image](https://github.com/arcaneenergy/godot-multimesh-scatter/assets/23486102/85c3114a-6029-417c-8fc8-f09ce10c68ae)

Set to (0,1,0) and they will all point upwards:
![image](https://github.com/arcaneenergy/godot-multimesh-scatter/assets/23486102/e3be325e-731c-4747-80d7-02b64a613249)
