### PR TITLE
Implement scale uniformity on instances

### DIFF
--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -469,23 +469,20 @@ func scatter(force := false) -> void:
 				global_transform.basis.x.cross(hit.normal),
 			).orthonormalized()
 		)
-		
-		var scale_x = _rng.randf_range(min_random_size.x, max_random_size.x)
-		var scale_y = _rng.randf_range(min_random_size.y, max_random_size.y)
-		var scale_z = _rng.randf_range(min_random_size.z, max_random_size.z)
-		
-		# change y and z scaling based on the x scaling, weighted by the scale uniformity factor
-		scale_y = scale_uniformity * scale_x + (1 - scale_uniformity) * scale_y
-		scale_z = scale_uniformity * scale_x + (1 - scale_uniformity) * scale_z
-		
+
+		var scale_x := _rng.randf_range(min_random_size.x, max_random_size.x)
+		var scale_y := _rng.randf_range(min_random_size.y, max_random_size.y)
+		var scale_z := _rng.randf_range(min_random_size.z, max_random_size.z)
+
+		# Change y and z scaling based on the x scaling, weighted by the scale uniformity factor
+		scale_y = scale_uniformity * scale_x + (1.0 - scale_uniformity) * scale_y
+		scale_z = scale_uniformity * scale_x + (1.0 - scale_uniformity) * scale_z
+
 		t = t\
 			.rotated(Vector3.RIGHT, deg_to_rad(_rng.randf_range(-random_rotation.x, random_rotation.x) + offset_rotation.x))\
 			.rotated(Vector3.UP, deg_to_rad(_rng.randf_range(-random_rotation.y, random_rotation.y) + offset_rotation.y))\
 			.rotated(Vector3.FORWARD, deg_to_rad(_rng.randf_range(-random_rotation.z, random_rotation.z) + offset_rotation.z))\
-			.scaled(iteration_scale * Vector3(
-				scale_x,
-				scale_y,
-				scale_z))
+			.scaled(iteration_scale * Vector3(scale_x, scale_y, scale_z))
 		t.origin = hit.position - global_position + offset_position
 		multimesh.set_instance_transform(i, t)
 


### PR DESCRIPTION
More tweaking after working with my tree instancing example. It looks odd when trees are scaled randomly between the random size limits. In this case I still wanted a pretty wide range of random scales for each instance (minimum 1x, max 3x), but wanted them to be scaled uniformly on all axes.

To fix this, I introduced a "Scale Uniformity" weighting factor. With a value of 1, the random value in the x scale (clamped to min/max)  is applied to y and z as well giving a uniform scale for that instance. At a value of 0, the original behavior is observed, where new random values are used for X, Y and Z independently.

You can blend between these two modes by using a factor between 0 and 1. See screenshots

Value of 0.0 (original behaviour):
![image](https://github.com/arcaneenergy/godot-multimesh-scatter/assets/23486102/fb511b2b-19fb-4a8f-b412-7610e545cee3)

Value 0.5:
![image](https://github.com/arcaneenergy/godot-multimesh-scatter/assets/23486102/a5e2ca71-1a46-46ba-8997-7a588b37aaca)

Value 1.0:
![image](https://github.com/arcaneenergy/godot-multimesh-scatter/assets/23486102/6a1afb01-8001-4318-8e0c-40ba9acb50da)
