### PR TITLE
Stop re-scattering on each scene save/load

### DIFF
--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -329,8 +329,6 @@ func _ready() -> void:
 	_update()
 
 func _notification(what: int) -> void:
-	if not is_inside_tree():
-		return
 	if NOTIFICATION_TRANSFORM_CHANGED:
 		_update()
 

--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -381,7 +381,8 @@ func _update_debug_area_size() -> void:
 				_debug_draw_instance.mesh.size = scatter_size
 
 func _update(force := false) -> void:
-	if !_space: return
+	if !_space:
+		return
 	scatter(force)
 	
 	if Engine.is_editor_hint():

--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -381,6 +381,8 @@ func _update_debug_area_size() -> void:
 				_debug_draw_instance.mesh.size = scatter_size
 
 func _update(force := false) -> void:
+	if not is_inside_tree():
+		return
 	if !_space:
 		return
 	scatter(force)

--- a/addons/multimesh_scatter/multimesh_scatter.gd
+++ b/addons/multimesh_scatter/multimesh_scatter.gd
@@ -329,7 +329,7 @@ func _ready() -> void:
 	_update()
 
 func _notification(what: int) -> void:
-	if NOTIFICATION_TRANSFORM_CHANGED:
+	if what == NOTIFICATION_TRANSFORM_CHANGED:
 		_update()
 
 func _ensure_has_mm() -> bool:


### PR DESCRIPTION
The plugin re-scatters meshes on each scene save and if I'm not mistaken, also on first time the scene is opened in the editor during a session. This is an issue because it spams version control with pointless diffs. Moving the `is_inside_tree()` check into the `_update()` function seems to stop this successfully.

As far as I can tell, this doesn't impact anything else; I did not find any difference in functionality between this PR and the current main branch.

This PR is _not_ related to #6.

Included are also a few small tweaks:
* formatting: add missing tabs in indented blocks and break after if statements (see: [style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html))
* add a missing comparison in the `_notification` function; `if NOTIFICATION_TRANSFORM_CHANGED` always defaulted to true because it's a positive integer.
* Removed the `is_inside_tree` check in `_notification` because it will be checked in `_update` anyway